### PR TITLE
Fix broken search in shell template

### DIFF
--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -66,7 +66,7 @@
                         {{/each}}
                     </ul>
                     {{#if search_target}}
-                        <form class="d-flex" role="search" target="{{search_target}}">
+                        <form class="d-flex" role="search" action="{{search_target}}">
                             <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"
                                    name="search">
                             <button class="btn btn-outline-success" type="submit">Search</button>


### PR DESCRIPTION
The shell template was using a "target" attribute on the search <form> element, instead of an "action" attribute. The SQL script responsible for the search should be specified in an "action" attribute, otherwise the search does not work.