### PR TITLE
Fix ErrorWithStatus bubbling

### DIFF
--- a/src/webserver/http.rs
+++ b/src/webserver/http.rs
@@ -159,6 +159,7 @@ async fn build_response_header_and_stream<S: Stream<Item = DbItem>>(
                 log::debug!("finished query");
                 continue;
             }
+            DbItem::Error(source_err) if matches!(source_err.downcast_ref(), Some(&ErrorWithStatus { status: _ }) ) => return Err(source_err),
             DbItem::Error(source_err) => head_context.handle_error(source_err).await?,
         };
         match page_context {

--- a/src/webserver/http.rs
+++ b/src/webserver/http.rs
@@ -159,7 +159,14 @@ async fn build_response_header_and_stream<S: Stream<Item = DbItem>>(
                 log::debug!("finished query");
                 continue;
             }
-            DbItem::Error(source_err) if matches!(source_err.downcast_ref(), Some(&ErrorWithStatus { status: _ }) ) => return Err(source_err),
+            DbItem::Error(source_err)
+                if matches!(
+                    source_err.downcast_ref(),
+                    Some(&ErrorWithStatus { status: _ })
+                ) =>
+            {
+                return Err(source_err)
+            }
             DbItem::Error(source_err) => head_context.handle_error(source_err).await?,
         };
         match page_context {


### PR DESCRIPTION
Since 0.10.0 ErrorWithStatus show as html error rendering.
This leads to breaking Basic Auth mechanism for instance.
The fix considers every ErrorWithStatus must not show details as html.