### PR TITLE
null variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,33 @@
 # CHANGELOG.md
 
-## unreleased
+## 0.16.0 (2023-11-19)
 
  - Add special handling of hidden inputs in [forms](https://sql.ophir.dev/documentation.sql?component=form#component). Hidden inputs are now completely invisible to the end user, facilitating the implementation of multi-step forms, csrf protaction, and other complex forms.
- - 18 new icons available (see https://github.com/tabler/tabler-icons/releases/tag/v2.40.0)
+ - 36 new icons available 
+   - https://github.com/tabler/tabler-icons/releases/tag/v2.40.0
+   - https://github.com/tabler/tabler-icons/releases/tag/v2.41.0
  - Support multiple statements in [`on_connect.sql`](./configuration.md) in MySQL.
- - Randomize postgres prepared statement names to avoid name collisions. This should fix a bug where SQLPage would report errors like `prepared statement "sqlx_s_3" already exists` when using a connection pooler in front of a PostgreSQL database.
+ - Randomize postgres prepared statement names to avoid name collisions. This should fix a bug where SQLPage would report errors like `prepared statement "sqlx_s_1" already exists` when using a connection pooler in front of a PostgreSQL database. It is still not recommended to use SQLPage with an external connection pooler (such as pgbouncer), because SQLPage already implements its own connection pool. If you really want to use a connection pooler, you should set the [`max_connections`](./configuration.md) configuration parameter to `1` to disable the connection pooling logic in SQLPage.
  - SQL statements are now prepared lazily right before their first execution, instead of all at once when a file is first loaded, which allows **referencing a temporary table created at the start of a file in a later statement** in the same file. This works by delegating statement preparation to the database interface library we use (sqlx). The logic of preparing statements and caching them for later reuse is now entirely delegated to sqlx. This also nicely simplifies the code and logic inside sqlpage itself, and should slightly improve performance and memory usage.
+   - Creating temporary tables at the start of a file is a nice way to keep state between multiple statements in a single file, without having to use variables, which can contain only a single string value: 
+     ```sql
+      DROP VIEW IF EXISTS current_user;
+
+      CREATE TEMPORARY VIEW current_user AS
+      SELECT * FROM users
+      INNER JOIN sessions ON sessions.user_id = users.id
+      WHERE sessions.session_id = sqlpage.cookie('session_id');
+      
+      SELECT 'card' as component,
+              'Welcome, ' || username as title
+      FROM current_user;
+      ```
+ - Add support for resetting variables to a `NULL` value using `SET`. Previously, storing `NULL` in a variable would store the string `'null'` instead of the `NULL` value. This is now fixed.
+    ```sql
+    SET myvar = NULL;
+    SELECT 'card' as component;
+    SELECT $myvar IS NULL as title; -- this used to display false, it now displays true
+    ```
 
 ## 0.15.2 (2023-11-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
  - 18 new icons available (see https://github.com/tabler/tabler-icons/releases/tag/v2.40.0)
  - Support multiple statements in [`on_connect.sql`](./configuration.md) in MySQL.
  - Randomize postgres prepared statement names to avoid name collisions. This should fix a bug where SQLPage would report errors like `prepared statement "sqlx_s_3" already exists` when using a connection pooler in front of a PostgreSQL database.
- - Delegate statement preparation to sqlx. The logic of preparing statements and caching them for later reuse is now entirely delegated to the sql driver library (sqlx). This simplifies the code and logic inside sqlpage itself. More importantly, statements are now prepared in a streaming fashion when a file is first loaded, instead of all at once, which allows referencing a temporary table created at the start of a file in a later statement in the same file.
+ - SQL statements are now prepared lazily right before their first execution, instead of all at once when a file is first loaded, which allows **referencing a temporary table created at the start of a file in a later statement** in the same file. This works by delegating statement preparation to the database interface library we use (sqlx). The logic of preparing statements and caching them for later reuse is now entirely delegated to sqlx. This also nicely simplifies the code and logic inside sqlpage itself, and should slightly improve performance and memory usage.
 
 ## 0.15.2 (2023-11-12)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.24"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "sqlpage"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "actix-rt",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlpage"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 description = "A SQL-only web application framework. Takes .sql files and formats the query result using pre-made configurable professional-looking components."
 keywords = ["web", "sql", "framework"]

--- a/examples/user-authentication/protected_page.sql
+++ b/examples/user-authentication/protected_page.sql
@@ -1,12 +1,12 @@
+SET username = (SELECT username FROM login_session WHERE id = sqlpage.cookie('session'));
+
 SELECT 'redirect' AS component,
         'signin.sql?error' AS link
-WHERE logged_in_user(sqlpage.cookie('session')) IS NULL;
--- logged_in_user is a custom postgres function defined in the first migration of this example
--- that avoids having to repeat `(SELECT username FROM login_session WHERE id = session_id)` everywhere. 
+WHERE $username IS NULL;
 
 SELECT 'shell' AS component, 'Protected page' AS title, 'lock' AS icon, '/' AS link, 'logout' AS menu_item;
 
 SELECT 'text' AS component,
-        'Welcome, ' || logged_in_user(sqlpage.cookie('session')) || ' !' AS title,
+        'Welcome, ' || $username || ' !' AS title,
         'This content is [top secret](https://youtu.be/dQw4w9WgXcQ).
         You cannot view it if you are not connected.' AS contents_md;

--- a/examples/user-authentication/sqlpage/migrations/0000_init.sql
+++ b/examples/user-authentication/sqlpage/migrations/0000_init.sql
@@ -8,10 +8,3 @@ CREATE TABLE login_session (
     username TEXT NOT NULL REFERENCES user_info(username),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-
--- A small pure utility function to get the current user from a session cookie.
--- In a database that does not support functions, you could inline this query
--- or use a view if you need more information from the user table
-CREATE FUNCTION logged_in_user(session_id TEXT) RETURNS TEXT AS $$
-    SELECT username FROM login_session WHERE id = session_id;
-$$ LANGUAGE SQL STABLE;

--- a/sqlpage/apexcharts.js
+++ b/sqlpage/apexcharts.js
@@ -1,4 +1,4 @@
-/* !include https://cdn.jsdelivr.net/npm/apexcharts@3.43.2-0/dist/apexcharts.min.js */
+/* !include https://cdn.jsdelivr.net/npm/apexcharts@3.44.0/dist/apexcharts.min.js */
 
 
 function sqlpage_chart() {

--- a/sqlpage/tabler-icons.svg
+++ b/sqlpage/tabler-icons.svg
@@ -1,1 +1,1 @@
-/* !include https://cdn.jsdelivr.net/npm/@tabler/icons@2.40.0/tabler-sprite.svg */
+/* !include https://cdn.jsdelivr.net/npm/@tabler/icons@2.41.0/tabler-sprite.svg */

--- a/tests/sql_test_files/it_works_set_variable_to_null.sql
+++ b/tests/sql_test_files/it_works_set_variable_to_null.sql
@@ -1,0 +1,9 @@
+set i_am_null = NULL;
+select 'text' as component,
+    CASE
+        WHEN $i_am_null IS NULL
+        THEN
+            'It works !'
+        ELSE
+            'error: expected null, got: ' || $i_am_null
+    END as contents;


### PR DESCRIPTION
- update dependencies
- Add support for resetting variables to a `NULL` value using `SET`. Previously, storing `NULL` in a variable would store the string `'null'` instead of the `NULL` value.
