### PR TITLE
Clarifies documentation site regarding the need to enclose http_header hyphenated names + typo fixes

### DIFF
--- a/examples/official-site/sqlpage/migrations/04_http_header.sql
+++ b/examples/official-site/sqlpage/migrations/04_http_header.sql
@@ -2,14 +2,20 @@
 INSERT INTO component (name, description, icon)
 VALUES (
         'http_header',
-        'An advanced component that can be used to create redirections, set a custom caching policy to your pages, or set any HTTP header.
+        'An advanced component that can be used to create redirections, set a custom caching
+            policy to your pages, and set any HTTP header, among other things.
         If you are a beginner, you probably don''t need this component.
-        When used, this component has to be the first component in the page, because once the page is sent to the browser, it is too late to change the headers.
-        Any valid HTTP header can be used as a top-level parameter for this component.
-        HTTP headers are additional pieces of information sent with responses to web requests that provide instructions
-            or metadata about the data being sent — for example,
+        HTTP headers are additional pieces of information sent with responses to web requests
+            that provide instructions or metadata about the data being sent — for example,
             setting cache control directives to control caching behavior
-            or specifying the content type of a response.',
+            or specifying the content type of a response.
+        When used, this component has to be the first component in the page, because once the
+            page is sent to the browser, it is too late to change the headers.
+        Any valid HTTP header name can be used as a top-level parameter for this component.
+        The examples shown here are just that, examples; and you can create any custom header
+            if needed simply by declaring it.
+        For example, the htmx javascript library uses an `HX-Redirect` header to prompt client-side redirects.
+        Note: if your header has hyphens in its name, you''ll need to enclose it (standard SQL uses double quotes).',
         'world-www'
     );
 -- Insert the parameters for the http_header component into the parameter table
@@ -23,7 +29,7 @@ INSERT INTO parameter (
     )
 VALUES (
         'http_header',
-        'Cache-Control',
+        '"Cache-Control"',
         'Directives for how long the page should be cached by the browser. Set this to max-age=N to keep the page in cache for N seconds.',
         'TEXT',
         TRUE,
@@ -31,7 +37,7 @@ VALUES (
     ),
     (
         'http_header',
-        'Content-Disposition',
+        '"Content-Disposition"',
         'Provides instructions on how the response content should be displayed or handled by the client, such as inline or as an attachment.',
         'TEXT',
         TRUE,
@@ -47,7 +53,7 @@ VALUES (
     ),
     (
         'http_header',
-        'Set-Cookie',
+        '"Set-Cookie"',
         'Sets a cookie in the client browser, used for session management and storing user-related information.',
         'TEXT',
         TRUE,
@@ -55,8 +61,16 @@ VALUES (
     ),
     (
         'http_header',
-        'Access-Control-Allow-Origin',
+        '"Access-Control-Allow-Origin"',
         'Specifies which origins are allowed to access the resource in a cross-origin request, used for implementing Cross-Origin Resource Sharing (CORS).',
+        'TEXT',
+        TRUE,
+        TRUE
+    ),
+    (
+        'http_header',
+        '"HX-Redirect"',
+        'An example of a custom header -- this one is used by the htmx javascript library to prompt its client-side redirects.',
         'TEXT',
         TRUE,
         TRUE
@@ -77,7 +91,7 @@ VALUES (
         JSON(
             '[{
                     "component": "http_header",
-                    "Cache-Control": "public, max-age=600, stale-while-revalidate=3600, stale-if-error=86400"
+                    "\"Cache-Control\"": "public, max-age=600, stale-while-revalidate=3600, stale-if-error=86400"
         }]'
         )
     ),

--- a/examples/official-site/sqlpage/migrations/05_cookie.sql
+++ b/examples/official-site/sqlpage/migrations/05_cookie.sql
@@ -1,4 +1,4 @@
--- Insert the http_header component into the component table
+-- Insert the cookie component into the component table
 INSERT INTO component (name, description, icon)
 VALUES (
         'cookie',
@@ -10,7 +10,7 @@ VALUES (
         After being set, a cookie can be accessed anywhere in your SQL code using the `sqlpage.cookie(''cookie_name'')` pseudo-function.',
         'cookie'
     );
--- Insert the parameters for the http_header component into the parameter table
+-- Insert the parameters for the cookie component into the parameter table
 INSERT INTO parameter (
         component,
         name,
@@ -99,7 +99,7 @@ VALUES (
         TRUE,
         TRUE
     );
--- Insert an example usage of the http_header component into the example table
+-- Insert an example usage of the cookie component into the example table
 INSERT INTO example (component, description)
 VALUES (
         'cookie',

--- a/examples/official-site/sqlpage/migrations/06_debug.sql
+++ b/examples/official-site/sqlpage/migrations/06_debug.sql
@@ -1,11 +1,11 @@
--- Insert the http_header component into the component table
+-- Insert the debug component into the component table
 INSERT INTO component (name, description, icon)
 VALUES (
         'debug',
         'Display all the parameters passed to the component. Useful for debugging: just replace the name of the component you want to debug with ''debug''.',
         'bug'
     );
--- Insert an example usage of the http_header component into the example table
+-- Insert an example usage of the debug component into the example table
 INSERT INTO example (component, description, properties)
 VALUES (
         'debug',

--- a/examples/official-site/sqlpage/migrations/07_authentication.sql
+++ b/examples/official-site/sqlpage/migrations/07_authentication.sql
@@ -1,4 +1,4 @@
--- Insert the http_header component into the component table
+-- Insert the authentication component into the component table
 INSERT INTO component (name, description, icon, introduced_in_version)
 VALUES (
         'authentication',
@@ -12,7 +12,7 @@ VALUES (
         'lock',
         '0.7.2'
     );
--- Insert the parameters for the http_header component into the parameter table
+-- Insert the parameters for the authentication component into the parameter table
 INSERT INTO parameter (
         component,
         name,
@@ -46,7 +46,7 @@ VALUES (
         TRUE
     );
 
--- Insert an example usage of the http_header component into the example table
+-- Insert an example usage of the authentication component into the example table
 INSERT INTO example (component, description)
 VALUES (
         'authentication',

--- a/examples/official-site/sqlpage/migrations/09_redirect.sql
+++ b/examples/official-site/sqlpage/migrations/09_redirect.sql
@@ -12,7 +12,7 @@ VALUES (
         'arrow-right',
         '0.7.2'
     );
--- Insert the parameters for the http_header component into the parameter table
+-- Insert the parameters for the redirect component into the parameter table
 INSERT INTO parameter (
         component,
         name,
@@ -29,7 +29,7 @@ VALUES (
         TRUE,
         FALSE
     );
--- Insert an example usage of the http_header component into the example table
+-- Insert an example usage of the redirect component into the example table
 INSERT INTO example (component, description)
 VALUES (
         'redirect',

--- a/examples/official-site/sqlpage/migrations/10_map.sql
+++ b/examples/official-site/sqlpage/migrations/10_map.sql
@@ -5,7 +5,7 @@ VALUES (
         'map',
         '0.8.0'
     );
--- Insert the parameters for the http_header component into the parameter table
+-- Insert the parameters for the map component into the parameter table
 INSERT INTO parameter (
         component,
         name,

--- a/examples/official-site/sqlpage/migrations/11_json.sql
+++ b/examples/official-site/sqlpage/migrations/11_json.sql
@@ -7,7 +7,7 @@ VALUES (
         'code',
         '0.9.0'
     );
--- Insert the parameters for the http_header component into the parameter table
+-- Insert the parameters for the json component into the parameter table
 INSERT INTO parameter (
         component,
         name,
@@ -24,7 +24,7 @@ VALUES (
         TRUE,
         FALSE
     );
--- Insert an example usage of the http_header component into the example table
+-- Insert an example usage of the json component into the example table
 INSERT INTO example (component, description)
 VALUES (
         'json',


### PR DESCRIPTION
Hi @lovasoa, the documentation site needs to specify that hyphenated http_headers (Cache-Control, Content-Disposition, etc) _do require the use of enclosing quotes when used as aliases_.
```sql
-- custom htmx header
select 'http_header' as component,
    "/home.sql" as "HX-Redirect";
```
It was also somewhat unclear that we could declare custom headers; the examples only specified a handful of standard headers, which might imply that we're limited to those.

Also, found some related typos in the migration comments 🐛