### PR TITLE
Adds `body_class` for form component

### DIFF
--- a/sqlpage/templates/form.handlebars
+++ b/sqlpage/templates/form.handlebars
@@ -7,7 +7,7 @@
     {{#if id}}action="#{{id}}"{{/if}}
     {{/if}}
 >
-    <fieldset class="form-fieldset">
+    <fieldset class="form-fieldset {{body_class}}">
         {{#if title}}
             <h2 class="text-center mb-3">{{title}}</h2>
         {{/if}}


### PR DESCRIPTION
Hey @lovasoa, what do you think of this tiny form component enhancement?

Allows adding classes to the fieldset element that contains the body of the form. Useful for things like inner padding, border adjustments, etc.

Would love to see something like this in the official component, and I can update the relevant documentation if this looks good to you!