### PR TITLE
Update button.handlebars adding after-icon

### DIFF
--- a/sqlpage/templates/button.handlebars
+++ b/sqlpage/templates/button.handlebars
@@ -17,6 +17,9 @@
             <span class="me-1">{{~icon_img icon~}}</span>
         {{~/if~}}
         {{~title~}}
+        {{~#if after_icon~}}
+            <span class="ms-1">{{~icon_img after_icon~}}</span>
+        {{~/if}}
     {{#if form}}
     </button>
     {{else}}


### PR DESCRIPTION
{{#if after_icon}}: This new block checks if the after_icon parameter is provided. If it is, it renders the icon after the text. In this way, the template will support both an icon before and after the text, depending on which parameters (icon or after_icon) are provided.