### PR TITLE
add uploaded_file_name function

### DIFF
--- a/examples/official-site/sqlpage/migrations/23_uploaded_file_functions.sql
+++ b/examples/official-site/sqlpage/migrations/23_uploaded_file_functions.sql
@@ -141,7 +141,7 @@ insert into uploaded_files (fname, content, uploaded) values (
 
 The file can be downloaded by clicking a link like this:
 ```sql
-select 'button' as component;
+select ''button'' as component;
 select name as title, content as link from uploaded_files where name = $file_name limit 1;
 ```
 

--- a/examples/official-site/sqlpage/migrations/23_uploaded_file_functions.sql
+++ b/examples/official-site/sqlpage/migrations/23_uploaded_file_functions.sql
@@ -141,11 +141,8 @@ insert into uploaded_files (fname, content, uploaded) values (
 
 The file can be downloaded by clicking a link like this:
 ```sql
-select 'text' as component, (
-  select '<a download="'||fname||'" href="'||content||'">Click to download '||fname||'</a>' from uploaded_files
-  where fname = $file_name
-  limit 1
-) as html;
+select 'button' as component;
+select name as title, content as link from uploaded_files where name = $file_name limit 1;
 ```
 
 > *Note*: because the file is ecoded as a data uri, the file is transferred to the client whether or not the link is clicked

--- a/examples/official-site/sqlpage/migrations/23_uploaded_file_functions.sql
+++ b/examples/official-site/sqlpage/migrations/23_uploaded_file_functions.sql
@@ -141,9 +141,11 @@ insert into uploaded_files (fname, content, uploaded) values (
 
 The file can be downloaded by clicking a link like this:
 ```sql
-select 'text' as component;
-select '<a download="'||fname||'" href="'||content||'">Click to download '||fname||'</a>' from uploaded_files
-where fname = $file_name as html;
+select 'text' as component, (
+  select '<a download="'||fname||'" href="'||content||'">Click to download '||fname||'</a>' from uploaded_files
+  where fname = $file_name
+  limit 1
+) as html;
 ```
 
 > *Note*: because the file is ecoded as a data uri, the file is transferred to the client whether or not the link is clicked

--- a/examples/official-site/sqlpage/migrations/23_uploaded_file_functions.sql
+++ b/examples/official-site/sqlpage/migrations/23_uploaded_file_functions.sql
@@ -109,7 +109,7 @@ where sqlpage.uploaded_file_mime_type(''myfile'') not in (select mime_type from 
 (
     'uploaded_file_name',
     '0.23.0',
-    'upload',
+    'file-description',
     'Returns the `filename` value in the `content-disposition` header.
 
 ## Example: saving uploaded file metadata for later download

--- a/src/webserver/database/sqlpage_functions/functions.rs
+++ b/src/webserver/database/sqlpage_functions/functions.rs
@@ -31,6 +31,7 @@ super::function_definition_macro::sqlpage_functions! {
 
     uploaded_file_mime_type((&RequestInfo), upload_name: Cow<str>);
     uploaded_file_path((&RequestInfo), upload_name: Cow<str>);
+    uploaded_file_name((&RequestInfo), upload_name: Cow<str>);
     url_encode(raw_text: Option<Cow<str>>);
 
     variables((&RequestInfo), get_or_post: Option<Cow<str>>);
@@ -425,6 +426,18 @@ async fn uploaded_file_path<'a>(
 ) -> Option<Cow<'a, str>> {
     let uploaded_file = request.uploaded_files.get(&*upload_name)?;
     Some(uploaded_file.file.path().to_string_lossy())
+}
+
+async fn uploaded_file_name<'a>(
+    request: &'a RequestInfo,
+    upload_name: Cow<'a, str>,
+) -> Option<Cow<'a, str>> {
+    let fname = request
+        .uploaded_files
+        .get(&*upload_name)?
+        .file_name
+        .as_ref()?;
+    Some(Cow::Borrowed(fname.as_str()))
 }
 
 /// escapes a string for use in a URL using percent encoding

--- a/tests/uploaded_file_name_test.sql
+++ b/tests/uploaded_file_name_test.sql
@@ -1,0 +1,3 @@
+-- display the file name of the uploaded file, unencoded, and nothing else
+select 'shell-empty' as component,
+    sqlpage.uploaded_file_name('my_file') as html;


### PR DESCRIPTION
Closes #333 

Tested with
```sql
SET fname = sqlpage.uploaded_file_name('f');

SELECT 'debug' AS component;
SELECT $fname AS fname;

SELECT 'form' AS component, 'post' AS method;
SELECT 'file' AS type, 'f' AS name, '' AS label;
```

Documentation tbd