### PR TITLE
Added CSV button size top-level parameter

### DIFF
--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -644,7 +644,8 @@ INSERT INTO parameter(component, name, description, type, top_level, optional) S
     ('title', 'The text displayed on the download button.', 'TEXT', TRUE, FALSE),
     ('filename', 'The name of the file that should be downloaded (without the extension).', 'TEXT', TRUE, TRUE),
     ('icon', 'Name of the icon (from tabler-icons.io) to display in the button.', 'ICON', TRUE, TRUE),
-    ('color', 'Color of the button', 'COLOR', TRUE, TRUE)
+    ('color', 'Color of the button', 'COLOR', TRUE, TRUE),
+    ('size', 'The size of the button (e.g., sm, lg).', 'TEXT', TRUE, TRUE)
 ) x;
 
 INSERT INTO example(component, description, properties) VALUES

--- a/sqlpage/templates/csv.handlebars
+++ b/sqlpage/templates/csv.handlebars
@@ -17,7 +17,7 @@
 {{~/each_row~}}
 "
        download="{{default filename title}}.csv"
-       class="btn btn-{{default color "primary"}}">
+       class="btn btn-{{default color "primary"}}{{#if size}} btn-{{size}}{{/if}}">
         {{~icon_img (default icon "download")~}}
         {{default title "Download"}}
     </a>


### PR DESCRIPTION
Hi,
I've added a CSV button size top-level parameter to the csv.handlebars & updated the documentation - copied button size parameter description and pasted it into the CSV button size description. This is my first pull request. Please feel free to tell me if you need anything more to be fulfilled before making a pull request.