### PR TITLE
adds semantic classes, ids, and tags

### DIFF
--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{language}}" style="font-size: {{default font_size 18}}px" {{#if html_class}}class="{{html_class}}"{{/if}}>
+<html lang="{{language}}" style="font-size: {{default font_size 18}}px" {{#if class}}class="{{class}}"{{/if}}>
 <head>
     <meta charset="utf-8"/>
     <title>{{default title "SQLPage"}}</title>

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{language}}" style="font-size: {{default font_size 18}}px">
+<html lang="{{language}}" style="font-size: {{default font_size 18}}px" {{#if html_class}}class="{{html_class}}"{{/if}}>
 <head>
     <meta charset="utf-8"/>
     <title>{{default title "SQLPage"}}</title>
@@ -49,76 +49,79 @@
     {{/if}}
 </head>
 
-<body class="layout-{{default layout 'boxed'}}" {{#if theme}}data-bs-theme="{{theme}}"{{/if}}>
-<div class="page">
+<body class="layout-{{default layout 'boxed'}} {{body_class}}" {{#if theme}}data-bs-theme="{{theme}}"{{/if}}>
+<div class="page" id="sqlpage_page_wrapper">
     {{#if title}}
-        <nav class="navbar navbar-expand-md navbar-light">
-            <div class="container-fluid">
-                <a class="navbar-brand flex-grow-1 overflow-hidden" href="{{#if link}}{{link}}{{else}}/{{/if}}">
-                    {{#if image}}
-                        <img src="{{image}}" alt="{{title}}" width="32" height="32"
-                             class="navbar-brand-image">
-                    {{/if}}
-                    {{#if icon}}
-                        {{~icon_img icon~}}
-                    {{/if}}
-                    <h1 class="mb-0 w-0 fs-2">{{title}}</h1>
-                </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-                        data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false"
-                        aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-                <div class="collapse navbar-collapse" id="navbar-menu">
-                    <ul class="navbar-nav ms-auto">
-                        {{#each (to_array menu_item)}}
-                            {{#if (eq (typeof this) 'object')}}
-                                <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
-                                <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
-                                    {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
-                                    role="button"
-                                >
-                                    {{this.title}}
-                                </a>
-                                {{#if this.submenu}}
-                                    <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
-                                        {{#each this.submenu}}
-                                            <a class="dropdown-item" href="{{this.link}}">
-                                                {{this.title}}
-                                            </a>
-                                        {{/each}}
-                                    </div>
-                                {{/if}}
-                                </li>
-                            {{else}}
-                                <li class="nav-item">
-                                    <a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>
-                                </li>
-                            {{/if}}
-                        {{/each}}
-                    </ul>
-                    {{#if search_target}}
-                        <form class="d-flex" role="search" action="{{search_target}}">
-                            <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search"
-                                   name="search" value="{{search_value}}">
-                            <button class="btn btn-outline-success" type="submit">Search</button>
-                        </form>
-                    {{/if}}
-                </div>
-            </div>
-        </nav>
+		<header id="sqlpage_header">
+			<nav class="navbar navbar-expand-md navbar-light">
+				<div class="container-fluid">
+					<a class="navbar-brand flex-grow-1 overflow-hidden" href="{{#if link}}{{link}}{{else}}/{{/if}}">
+						{{#if image}}
+							<img src="{{image}}" alt="{{title}}" width="32" height="32"
+								class="navbar-brand-image">
+						{{/if}}
+						{{#if icon}}
+							{{~icon_img icon~}}
+						{{/if}}
+						<h1 class="mb-0 w-0 fs-2">{{title}}</h1>
+					</a>
+					<button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+						data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false"
+						aria-label="Toggle navigation">
+						<span class="navbar-toggler-icon"></span>
+					</button>
+					<div class="collapse navbar-collapse" id="navbar-menu">
+						<ul class="navbar-nav ms-auto">
+							{{#each (to_array menu_item)}}
+								{{#if (eq (typeof this) 'object')}}
+									<li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
+									<a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
+										{{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
+										role="button"
+									>
+										{{this.title}}
+									</a>
+									{{#if this.submenu}}
+										<div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
+											{{#each this.submenu}}
+												<a class="dropdown-item" href="{{this.link}}">
+													{{this.title}}
+												</a>
+											{{/each}}
+										</div>
+									{{/if}}
+									</li>
+								{{else}}
+									<li class="nav-item">
+										<a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>
+									</li>
+								{{/if}}
+							{{/each}}
+						</ul>
+						{{#if search_target}}
+							<form class="d-flex" role="search" action="{{search_target}}">
+								<input class="form-control me-2" type="search" placeholder="Search" aria-label="Search" name="search" value="{{search_value}}">
+								<button class="btn btn-outline-success" type="submit">Search</button>
+							</form>
+						{{/if}}
+					</div>
+				</div>
+			</nav>
+		</header>
     {{/if}}
-    <main class="page-wrapper container-xl pt-3 px-md-5 px-sm-3">
+    <main class="page-wrapper container-xl pt-3 px-md-5 px-sm-3" id="sqlpage_main_wrapper">
         {{~#each_row~}}{{~/each_row~}}
     </main>
 </div>
-<div class="w-100 text-center fs-6 my-2 text-secondary">
-    {{#if footer}}
-        {{{markdown footer}}}
-    {{else}}
-        <!-- You can change this footer using the 'footer' parameter of the 'shell' component -->
-        Built with <a class="text-reset" href="https://sql.ophir.dev" title="SQLPage v{{buildinfo 'CARGO_PKG_VERSION'}}">SQLPage</a>
-    {{/if}}
-</div>
+<footer class="w-100 text-center fs-6 my-2 text-secondary" id="sqlpage_footer">
+	<div class="sqlpage_footer_content">
+		{{#if footer}}
+			{{{markdown footer}}}
+		{{else}}
+			<!-- You can change this footer using the 'footer' parameter of the 'shell' component -->
+			Built with <a class="text-reset" href="https://sql.ophir.dev" title="SQLPage v{{buildinfo 'CARGO_PKG_VERSION'}}">SQLPage</a>
+		{{/if}}
+	</div>
+</footer>
 </body>
 </html>

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -53,60 +53,60 @@
 <div class="page" id="sqlpage_page_wrapper">
     {{#if title}}
         <header id="sqlpage_header">
-            <nav class="navbar navbar-expand-md navbar-light">
-                <div class="container-fluid">
-                    <a class="navbar-brand flex-grow-1 overflow-hidden" href="{{#if link}}{{link}}{{else}}/{{/if}}">
-                        {{#if image}}
-                            <img src="{{image}}" alt="{{title}}" width="32" height="32"
-                                class="navbar-brand-image">
+        <nav class="navbar navbar-expand-md navbar-light">
+        <div class="container-fluid">
+            <a class="navbar-brand flex-grow-1 overflow-hidden" href="{{#if link}}{{link}}{{else}}/{{/if}}">
+                {{#if image}}
+                    <img src="{{image}}" alt="{{title}}" width="32" height="32"
+                        class="navbar-brand-image">
+                {{/if}}
+                {{#if icon}}
+                    {{~icon_img icon~}}
+                {{/if}}
+                <h1 class="mb-0 w-0 fs-2">{{title}}</h1>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false"
+                aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbar-menu">
+                <ul class="navbar-nav ms-auto">
+                    {{#each (to_array menu_item)}}
+                        {{#if (eq (typeof this) 'object')}}
+                            <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
+                            <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
+                                {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
+                                role="button"
+                            >
+                                {{this.title}}
+                            </a>
+                            {{#if this.submenu}}
+                                <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
+                                    {{#each this.submenu}}
+                                        <a class="dropdown-item" href="{{this.link}}">
+                                            {{this.title}}
+                                        </a>
+                                    {{/each}}
+                                </div>
+                            {{/if}}
+                            </li>
+                        {{else}}
+                            <li class="nav-item">
+                                <a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>
+                            </li>
                         {{/if}}
-                        {{#if icon}}
-                            {{~icon_img icon~}}
-                        {{/if}}
-                        <h1 class="mb-0 w-0 fs-2">{{title}}</h1>
-                    </a>
-                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-                        data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false"
-                        aria-label="Toggle navigation">
-                        <span class="navbar-toggler-icon"></span>
-                    </button>
-                    <div class="collapse navbar-collapse" id="navbar-menu">
-                        <ul class="navbar-nav ms-auto">
-                            {{#each (to_array menu_item)}}
-                                {{#if (eq (typeof this) 'object')}}
-                                    <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
-                                    <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
-                                        {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
-                                        role="button"
-                                    >
-                                        {{this.title}}
-                                    </a>
-                                    {{#if this.submenu}}
-                                        <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
-                                            {{#each this.submenu}}
-                                                <a class="dropdown-item" href="{{this.link}}">
-                                                    {{this.title}}
-                                                </a>
-                                            {{/each}}
-                                        </div>
-                                    {{/if}}
-                                    </li>
-                                {{else}}
-                                    <li class="nav-item">
-                                        <a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>
-                                    </li>
-                                {{/if}}
-                            {{/each}}
-                        </ul>
-                        {{#if search_target}}
-                            <form class="d-flex" role="search" action="{{search_target}}">
-                                <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search" name="search" value="{{search_value}}">
-                                <button class="btn btn-outline-success" type="submit">Search</button>
-                            </form>
-                        {{/if}}
-                    </div>
-                </div>
-            </nav>
+                    {{/each}}
+                </ul>
+                {{#if search_target}}
+                    <form class="d-flex" role="search" action="{{search_target}}">
+                        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search" name="search" value="{{search_value}}">
+                        <button class="btn btn-outline-success" type="submit">Search</button>
+                    </form>
+                {{/if}}
+            </div>
+        </div>
+        </nav>
         </header>
     {{/if}}
     <main class="page-wrapper container-xl pt-3 px-md-5 px-sm-3" id="sqlpage_main_wrapper">

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -49,79 +49,79 @@
     {{/if}}
 </head>
 
-<body class="layout-{{default layout 'boxed'}} {{body_class}}" {{#if theme}}data-bs-theme="{{theme}}"{{/if}}>
+<body class="layout-{{default layout 'boxed'}}" {{#if theme}}data-bs-theme="{{theme}}"{{/if}}>
 <div class="page" id="sqlpage_page_wrapper">
     {{#if title}}
-		<header id="sqlpage_header">
-			<nav class="navbar navbar-expand-md navbar-light">
-				<div class="container-fluid">
-					<a class="navbar-brand flex-grow-1 overflow-hidden" href="{{#if link}}{{link}}{{else}}/{{/if}}">
-						{{#if image}}
-							<img src="{{image}}" alt="{{title}}" width="32" height="32"
-								class="navbar-brand-image">
-						{{/if}}
-						{{#if icon}}
-							{{~icon_img icon~}}
-						{{/if}}
-						<h1 class="mb-0 w-0 fs-2">{{title}}</h1>
-					</a>
-					<button class="navbar-toggler" type="button" data-bs-toggle="collapse"
-						data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false"
-						aria-label="Toggle navigation">
-						<span class="navbar-toggler-icon"></span>
-					</button>
-					<div class="collapse navbar-collapse" id="navbar-menu">
-						<ul class="navbar-nav ms-auto">
-							{{#each (to_array menu_item)}}
-								{{#if (eq (typeof this) 'object')}}
-									<li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
-									<a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
-										{{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
-										role="button"
-									>
-										{{this.title}}
-									</a>
-									{{#if this.submenu}}
-										<div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
-											{{#each this.submenu}}
-												<a class="dropdown-item" href="{{this.link}}">
-													{{this.title}}
-												</a>
-											{{/each}}
-										</div>
-									{{/if}}
-									</li>
-								{{else}}
-									<li class="nav-item">
-										<a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>
-									</li>
-								{{/if}}
-							{{/each}}
-						</ul>
-						{{#if search_target}}
-							<form class="d-flex" role="search" action="{{search_target}}">
-								<input class="form-control me-2" type="search" placeholder="Search" aria-label="Search" name="search" value="{{search_value}}">
-								<button class="btn btn-outline-success" type="submit">Search</button>
-							</form>
-						{{/if}}
-					</div>
-				</div>
-			</nav>
-		</header>
+        <header id="sqlpage_header">
+            <nav class="navbar navbar-expand-md navbar-light">
+                <div class="container-fluid">
+                    <a class="navbar-brand flex-grow-1 overflow-hidden" href="{{#if link}}{{link}}{{else}}/{{/if}}">
+                        {{#if image}}
+                            <img src="{{image}}" alt="{{title}}" width="32" height="32"
+                                class="navbar-brand-image">
+                        {{/if}}
+                        {{#if icon}}
+                            {{~icon_img icon~}}
+                        {{/if}}
+                        <h1 class="mb-0 w-0 fs-2">{{title}}</h1>
+                    </a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                        data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false"
+                        aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbar-menu">
+                        <ul class="navbar-nav ms-auto">
+                            {{#each (to_array menu_item)}}
+                                {{#if (eq (typeof this) 'object')}}
+                                    <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
+                                    <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
+                                        {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
+                                        role="button"
+                                    >
+                                        {{this.title}}
+                                    </a>
+                                    {{#if this.submenu}}
+                                        <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
+                                            {{#each this.submenu}}
+                                                <a class="dropdown-item" href="{{this.link}}">
+                                                    {{this.title}}
+                                                </a>
+                                            {{/each}}
+                                        </div>
+                                    {{/if}}
+                                    </li>
+                                {{else}}
+                                    <li class="nav-item">
+                                        <a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>
+                                    </li>
+                                {{/if}}
+                            {{/each}}
+                        </ul>
+                        {{#if search_target}}
+                            <form class="d-flex" role="search" action="{{search_target}}">
+                                <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search" name="search" value="{{search_value}}">
+                                <button class="btn btn-outline-success" type="submit">Search</button>
+                            </form>
+                        {{/if}}
+                    </div>
+                </div>
+            </nav>
+        </header>
     {{/if}}
     <main class="page-wrapper container-xl pt-3 px-md-5 px-sm-3" id="sqlpage_main_wrapper">
         {{~#each_row~}}{{~/each_row~}}
     </main>
 </div>
 <footer class="w-100 text-center fs-6 my-2 text-secondary" id="sqlpage_footer">
-	<div class="sqlpage_footer_content">
-		{{#if footer}}
-			{{{markdown footer}}}
-		{{else}}
-			<!-- You can change this footer using the 'footer' parameter of the 'shell' component -->
-			Built with <a class="text-reset" href="https://sql.ophir.dev" title="SQLPage v{{buildinfo 'CARGO_PKG_VERSION'}}">SQLPage</a>
-		{{/if}}
-	</div>
+    <div class="sqlpage_footer_content">
+        {{#if footer}}
+            {{{markdown footer}}}
+        {{else}}
+            <!-- You can change this footer using the 'footer' parameter of the 'shell' component -->
+            Built with <a class="text-reset" href="https://sql.ophir.dev" title="SQLPage v{{buildinfo 'CARGO_PKG_VERSION'}}">SQLPage</a>
+        {{/if}}
+    </div>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
Adds semantic classes, ids, and tag names

Should give us more semantic CSS styling control. Example, `body` element theming, [à la Shoelace](https://shoelace.style/getting-started/themes):
```sql
select 'shell' as component,
    'sl-theme-dark' as body_class,
    [...]
```


- - -

⚠️ The new `<footer>` and `<header>` tags may break styling that relied on css selections such as `body > div:last-of-type {...}` prior to semantic tagging.