### PR TITLE
Added "overflow" attribute to the "table" component

### DIFF
--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -591,6 +591,7 @@ INSERT INTO parameter(component, name, description, type, top_level, optional) S
     ('striped_columns', 'Whether to add zebra-striping to any table column.', 'BOOLEAN', TRUE, TRUE),
     ('hover', 'Whether to enable a hover state on table rows.', 'BOOLEAN', TRUE, TRUE),
     ('border', 'Whether to draw borders on all sides of the table and cells.', 'BOOLEAN', TRUE, TRUE),
+    ('overflow', 'Whether to to let "wide" tables overflow across the right border and enable browser-based horizontal scrolling.', 'BOOLEAN', TRUE, TRUE),
     ('small', 'Whether to use compact table.', 'BOOLEAN', TRUE, TRUE),
     ('description','Description of the table content and helps users with screen readers to find a table and understand what it’s.','TEXT',TRUE,TRUE),
     -- row level

--- a/sqlpage/templates/table.handlebars
+++ b/sqlpage/templates/table.handlebars
@@ -1,4 +1,4 @@
-<div class="card my-2 {{class}}" {{#if id}}id="{{id}}"{{/if}}>
+<div class="card my-2 {{class}}" {{#if overflow}}style="width: fit-content;"{{/if}} {{#if id}}id="{{id}}"{{/if}}>
     <div class="card-body">
         <div class="table-responsive" {{#if (or sort search)}}data-pre-init="table"{{/if}}>
             {{#if search}}


### PR DESCRIPTION
The "table" component template will now set the width property of the table component div to "fit-content" if the table defines a boolean "overflow" attribute set to TRUE.

This feature is useful for "wide" tables, as it prevents columns clipping on the right, enabling horizontal scrolling via the browser scrollbar.