### PR TITLE
Parse JSON menu_item for SQLite and skip blank items

### DIFF
--- a/examples/official-site/examples/dynamic_menu.sql
+++ b/examples/official-site/examples/dynamic_menu.sql
@@ -1,0 +1,29 @@
+SET $dummy = ifnull(:menu, abs(random()) % 5);
+
+SELECT 
+    'shell'             AS component,
+    'SQLPage'           AS title,
+    'database'          AS icon,
+    '/'                 AS link,
+    iif($dummy = 1, NULL, '{"title":"About","submenu":[{"link":"/safety.sql","title":"Security"},{"link":"/performance.sql","title":"Performance"}]}') AS menu_item,
+    iif($dummy = 2, '{}', '{"title":"Examples","submenu":[{"link":"/examples/tabs.sql","title":"Tabs"},{"link":"/examples/layouts.sql","title":"Layouts"}]}') AS menu_item,
+    iif($dummy = 3, NULL, '{"title":"Community","submenu":[{"link":"blog.sql","title":"Blog"},{"link":"//github.com/lovasoa/sqlpage/issues","title":"Report a bug"}]}') AS menu_item,
+    iif($dummy = 4, '{}', '{"title":"Documentation","submenu":[{"link":"/your-first-sql-website","title":"Getting started"},{"link":"/components.sql","title":"All Components"}]}') AS menu_item,
+    'Official [SQLPage](https://sql.ophir.dev) documentation' as footer;
+
+
+SELECT 
+    'form'              AS component,
+    'Hide Menu'         AS validate,
+    sqlpage.path()      AS action;
+SELECT 
+    'select'            AS type,
+    'menu'              AS name,
+    'Hide Menu'         AS label,
+    2                   AS width,
+    CAST($dummy AS INT) AS value,
+    '[{"label": "None",          "value": 0},
+      {"label": "About",         "value": 1}, 
+      {"label": "Examples",      "value": 2}, 
+      {"label": "Community",     "value": 3},
+      {"label": "Documentation", "value": 4}]' AS options;

--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -898,6 +898,47 @@ FROM my_menu_items
 ```
 
 (check your database documentation for the exact syntax of the `json_group_array` function).
+
+Another "dynamic" aspect is when menu items are adjusted based on the environment. For example,
+Logout/UserProfile buttons may be presented to an authenticated user and Login/SignUp, otherwise
+(such an example will presented in a separate demo). The following simple example demonstrates
+the concept by hiding one arbitrary menu when the page is loaded. Then you can select from a
+dropdown menu, which menu to hide. To hide a menu item, return NULL or empty JSON object ''{}''
+as demonstrated below.
+
+```sql
+SET $dummy = ifnull(:menu, abs(random()) % 5);
+
+SELECT 
+    ''shell''             AS component,
+    ''SQLPage''           AS title,
+    ''database''          AS icon,
+    ''/''                 AS link,
+    iif($dummy = 1, NULL, ''{"title":"About","submenu":[{"link":"/safety.sql","title":"Security"},{"link":"/performance.sql","title":"Performance"}]}'') AS menu_item,
+    iif($dummy = 2, ''{}'', ''{"title":"Examples","submenu":[{"link":"/examples/tabs.sql","title":"Tabs"},{"link":"/examples/layouts.sql","title":"Layouts"}]}'') AS menu_item,
+    iif($dummy = 3, NULL, ''{"title":"Community","submenu":[{"link":"blog.sql","title":"Blog"},{"link":"//github.com/lovasoa/sqlpage/issues","title":"Report a bug"}]}'') AS menu_item,
+    iif($dummy = 4, ''{}'', ''{"title":"Documentation","submenu":[{"link":"/your-first-sql-website","title":"Getting started"},{"link":"/components.sql","title":"All Components"}]}'') AS menu_item,
+    ''Official [SQLPage](https://sql.ophir.dev) documentation'' as footer;
+
+
+SELECT 
+    ''form''              AS component,
+    ''Hide Menu''         AS validate,
+    sqlpage.path()      AS action;
+SELECT 
+    ''select''            AS type,
+    ''menu''              AS name,
+    ''Hide Menu''         AS label,
+    2                   AS width,
+    CAST($dummy AS INT) AS value,
+    ''[{"label": "None",          "value": 0},
+      {"label": "About",         "value": 1}, 
+      {"label": "Examples",      "value": 2}, 
+      {"label": "Community",     "value": 3},
+      {"label": "Documentation", "value": 4}]'' AS options;
+```
+
+Follow [this link](examples/dynamic_menu.sql) to try this code.
 ', NULL),
     ('shell', '
 ### A page without a shell

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -76,12 +76,14 @@
                         {{#if (eq (typeof (parse_json this)) 'object')}}
                             {{#with (parse_json this)}}
                                 <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
-                                <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
-                                    {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
-                                    role="button"
-                                >
-                                    {{this.title}}
-                                </a>
+                                {{#if (gt (len this.title) 0)}}
+                                    <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
+                                        {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
+                                        role="button"
+                                    >
+                                        {{this.title}}
+                                    </a>
+                                {{/if}}
                                 {{#if this.submenu}}
                                     <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
                                         {{#each this.submenu}}

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -73,24 +73,26 @@
             <div class="collapse navbar-collapse" id="navbar-menu">
                 <ul class="navbar-nav ms-auto">
                     {{#each (to_array menu_item)}}
-                        {{#if (eq (typeof this) 'object')}}
-                            <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
-                            <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
-                                {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
-                                role="button"
-                            >
-                                {{this.title}}
-                            </a>
-                            {{#if this.submenu}}
-                                <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
-                                    {{#each this.submenu}}
-                                        <a class="dropdown-item" href="{{this.link}}">
-                                            {{this.title}}
-                                        </a>
-                                    {{/each}}
-                                </div>
-                            {{/if}}
-                            </li>
+                        {{#if (eq (typeof (parse_json this)) 'object')}}
+                            {{#with (parse_json this)}}
+                                <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
+                                <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
+                                    {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
+                                    role="button"
+                                >
+                                    {{this.title}}
+                                </a>
+                                {{#if this.submenu}}
+                                    <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
+                                        {{#each this.submenu}}
+                                            <a class="dropdown-item" href="{{this.link}}">
+                                                {{this.title}}
+                                            </a>
+                                        {{/each}}
+                                    </div>
+                                {{/if}}
+                                </li>
+                            {{/with}}
                         {{else}}
                             <li class="nav-item">
                                 <a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -73,28 +73,28 @@
             <div class="collapse navbar-collapse" id="navbar-menu">
                 <ul class="navbar-nav ms-auto">
                     {{#each (to_array menu_item)}}
-                        {{#if (eq (typeof (parse_json this)) 'object')}}
+                        {{#if (or (eq (typeof this) 'object') (and (eq (typeof this) 'string') (starts_with this '{')))}}
                             {{#with (parse_json this)}}
                                 <li class="nav-item{{#if this.submenu}} dropdown{{/if}}">
-                                {{#if (gt (len this.title) 0)}}
-                                    <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
-                                        {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
-                                        role="button"
-                                    >
-                                        {{this.title}}
-                                    </a>
-                                {{/if}}
-                                {{#if this.submenu}}
-                                    <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
-                                        {{#each this.submenu}}
-                                            {{#if (gt (len this.title) 0)}}
-                                                <a class="dropdown-item" href="{{this.link}}">
-                                                    {{this.title}}
-                                                </a>
-                                            {{/if}}
-                                        {{/each}}
-                                    </div>
-                                {{/if}}
+                                    {{#if (gt (len this.title) 0)}}
+                                        <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
+                                            {{#if this.submenu}}data-bs-toggle="dropdown" data-bs-auto-close="outside"{{/if}}
+                                            role="button"
+                                        >
+                                            {{this.title}}
+                                        </a>
+                                    {{/if}}
+                                    {{#if this.submenu}}
+                                        <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
+                                            {{#each this.submenu}}
+                                                {{#if (gt (len this.title) 0)}}
+                                                    <a class="dropdown-item" href="{{this.link}}">
+                                                        {{this.title}}
+                                                    </a>
+                                                {{/if}}
+                                            {{/each}}
+                                        </div>
+                                    {{/if}}
                                 </li>
                             {{/with}}
                         {{else}}
@@ -104,6 +104,7 @@
                                 </li>
                             {{/if}}
                         {{/if}}
+
                     {{/each}}
                 </ul>
                 {{#if search_target}}

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -85,18 +85,22 @@
                                 {{#if this.submenu}}
                                     <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
                                         {{#each this.submenu}}
-                                            <a class="dropdown-item" href="{{this.link}}">
-                                                {{this.title}}
-                                            </a>
+                                            {{#if (gt (len this) 0)}}
+                                                <a class="dropdown-item" href="{{this.link}}">
+                                                    {{this.title}}
+                                                </a>
+                                            {{/if}}
                                         {{/each}}
                                     </div>
                                 {{/if}}
                                 </li>
                             {{/with}}
                         {{else}}
-                            <li class="nav-item">
-                                <a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>
-                            </li>
+                            {{#if (gt (len this) 0)}}
+                                <li class="nav-item">
+                                    <a class="nav-link text-capitalize" href="{{this}}.sql">{{this}}</a>
+                                </li>
+                            {{/if}}
                         {{/if}}
                     {{/each}}
                 </ul>

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -85,7 +85,7 @@
                                 {{#if this.submenu}}
                                     <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
                                         {{#each this.submenu}}
-                                            {{#if (gt (len this) 0)}}
+                                            {{#if (gt (len this.title) 0)}}
                                                 <a class="dropdown-item" href="{{this.link}}">
                                                     {{this.title}}
                                                 </a>


### PR DESCRIPTION
Use parse_json helper to enable the use of the object form of "shell" with JSON containing menu items. Also in this pull request is an explicit filter on blank items (for example, generated via `NULL AS menu_item` or via `'' AS menu_item`). The latter feature simplifier creation of dynamic menus based on certain conditions, such as whether the user is authenticated or not. 

Note, however, `'' AS menu_item` presently fails due to parse_json and should not be used. `'{}' AS menu-item` apparently works fine.