### PR TITLE
Daniel/450 readonly disabled for textarea

### DIFF
--- a/sqlpage/templates/form.handlebars
+++ b/sqlpage/templates/form.handlebars
@@ -64,6 +64,8 @@
                         {{~#if id}} id="{{id}}" {{/if~}}
                         {{~#if required}} required="required" {{/if~}}
                         {{~#if autofocus}} autofocus {{/if~}}
+                        {{~#if disabled}}disabled {{/if~}}
+                        {{~#if readonly}}readonly {{/if~}}
                         {{~#if multiple}} multiple {{/if~}}
                         {{~#if (or dropdown searchable)}} 
                             data-pre-init="select-dropdown"

--- a/sqlpage/templates/form.handlebars
+++ b/sqlpage/templates/form.handlebars
@@ -65,7 +65,6 @@
                         {{~#if required}} required="required" {{/if~}}
                         {{~#if autofocus}} autofocus {{/if~}}
                         {{~#if disabled}}disabled {{/if~}}
-                        {{~#if readonly}}readonly {{/if~}}
                         {{~#if multiple}} multiple {{/if~}}
                         {{~#if (or dropdown searchable)}} 
                             data-pre-init="select-dropdown"

--- a/sqlpage/templates/form.handlebars
+++ b/sqlpage/templates/form.handlebars
@@ -54,6 +54,8 @@
                             {{~#if maxlength}}maxlength="{{maxlength}}" {{/if~}}
                             {{~#if required}}required="required" {{/if~}}
                             {{~#if autofocus}}autofocus {{/if~}}
+                            {{~#if disabled}}disabled {{/if~}}
+                            {{~#if readonly}}readonly {{/if~}}
                         >
                         {{~#if value}}{{value}}{{/if~}}
                         </textarea>


### PR DESCRIPTION
Closes #450 

Tested with this:
```sql
SELECT 'form' AS component, 'post' AS method;
SELECT 'select' AS type
, json('[
  { "label": "a", "value": "a", "selected": true },
  { "label": "b", "value": "b", "selected": false },
  { "label": "c", "value": "b", "selected": true },
]') AS options
, TRUE AS multiple
, TRUE AS dropdown
, TRUE AS readonly
, 's' AS name
;
SELECT 'textarea' AS type
, 'abc' AS value
, 'ta' AS name
, TRUE AS readonly
;
```
* disabled works fine for textarea and select and dropdown select
* readonly works fine for textarea but not for dropdown select, so I removed implementation of readonly on select altogether