### PR TITLE
(feature) add sqlpage.query_string()

### DIFF
--- a/src/webserver/database/sqlpage_functions/functions.rs
+++ b/src/webserver/database/sqlpage_functions/functions.rs
@@ -21,6 +21,7 @@ super::function_definition_macro::sqlpage_functions! {
     header((&RequestInfo), name: Cow<str>);
 
     path((&RequestInfo));
+    query_string((&RequestInfo));
     persist_uploaded_file((&RequestInfo), field_name: Cow<str>, folder: Option<Cow<str>>, allowed_extensions: Option<Cow<str>>);
     protocol((&RequestInfo));
 
@@ -188,6 +189,10 @@ async fn header<'a>(request: &'a RequestInfo, name: Cow<'a, str>) -> Option<Cow<
 /// Returns the path component of the URL of the current request.
 async fn path(request: &RequestInfo) -> &str {
     &request.path
+}
+
+async fn query_string(request: &RequestInfo) -> &str {
+    &request.query_string
 }
 
 const DEFAULT_ALLOWED_EXTENSIONS: &str =

--- a/src/webserver/http_request_info.rs
+++ b/src/webserver/http_request_info.rs
@@ -28,6 +28,7 @@ use super::request_variables::ParamMap;
 pub struct RequestInfo {
     pub method: actix_web::http::Method,
     pub path: String,
+    pub query_string: String,
     pub protocol: String,
     pub get_variables: ParamMap,
     pub post_variables: ParamMap,
@@ -45,6 +46,7 @@ impl Clone for RequestInfo {
         Self {
             method: self.method.clone(),
             path: self.path.clone(),
+            query_string: self.query_string.clone(),
             protocol: self.protocol.clone(),
             get_variables: self.get_variables.clone(),
             post_variables: self.post_variables.clone(),
@@ -74,6 +76,7 @@ pub(crate) async fn extract_request_info(
             String::from_utf8_lossy(value.as_bytes()).to_string(),
         )
     });
+    let query_string = req.query_string().to_string();
     let get_variables = web::Query::<Vec<(String, String)>>::from_query(req.query_string())
         .map(web::Query::into_inner)
         .unwrap_or_default();
@@ -92,6 +95,7 @@ pub(crate) async fn extract_request_info(
     Ok(RequestInfo {
         method,
         path: req.path().to_string(),
+        query_string,
         headers: param_map(headers),
         get_variables: param_map(get_variables),
         post_variables: param_map(post_variables),

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -200,6 +200,22 @@ async fn test_overwrite_variable() -> actix_web::Result<()> {
     Ok(())
 }
 
+#[actix_web::test]
+async fn test_query() -> actix_web::Result<()> {
+    let query_string = "source=web&q=sqlpage+github";
+    let url = format!("/tests/sql_test_files/it_works_query_string.sql?{}", query_string);
+    let req = get_request_to(url.as_str()).await?.to_srv_request();
+    let resp = main_handler(req).await?;
+
+    assert_eq!(resp.status(), StatusCode::FOUND);
+    let redirect = resp.headers().get("Location").unwrap().to_str().unwrap();
+    assert!(
+        redirect.contains("login.sql?source=web&q=sqlpage+github"),
+        "{redirect}\nexpected to contain: [login.sql?source=web&q=sqlpage+github]"
+    );
+    Ok(())
+}
+
 async fn test_file_upload(target: &str) -> actix_web::Result<()> {
     let req = get_request_to(target)
         .await?

--- a/tests/sql_test_files/it_works_query_string.sql
+++ b/tests/sql_test_files/it_works_query_string.sql
@@ -1,0 +1,9 @@
+SELECT
+    'dynamic' AS component,
+    CASE sqlpage.query_string()
+        WHEN 'x=1' THEN
+            '[{"component":"text"}, {"contents":"It works !"}]'
+        ELSE
+            '[{"component":"redirect", "link":"login.sql?' || sqlpage.query_string() || '"}]'
+    END AS properties
+;


### PR DESCRIPTION
Adds the `sqlpage.query_string()` SQLPage function.

There are a few auth-related scenarios where it is useful to be able to directly access the query string and propagate it, for example when redirecting to a login page from a url with query string, and then redirecting the user back to that url on successful login.

There may be better ways to do this, but here is a simple `query_string` function for your consideration.