### PR TITLE
Change the sidebar theme as "sidebar_theme"

### DIFF
--- a/examples/official-site/sqlpage/migrations/01_documentation.sql
+++ b/examples/official-site/sqlpage/migrations/01_documentation.sql
@@ -868,6 +868,7 @@ INSERT INTO parameter(component, name, description, type, top_level, optional) S
     ('language', 'The language of the page. This can be used by search engines and screen readers to determine in which language the page is written.', 'TEXT', TRUE, TRUE),
     ('refresh', 'Number of seconds after which the page should refresh. This can be useful to display dynamic content that updates automatically.', 'INTEGER', TRUE, TRUE),
     ('sidebar', 'Whether the menu defined by menu_item should be displayed on the left side of the page instead of the top. Introduced in v0.27.', 'BOOLEAN', TRUE, TRUE),
+    ('sidebar_theme', 'Used with sidebar property, It can be set to "dark" to exclusively set the sidebar into dark theme.', 'BOOLEAN', TRUE, TRUE),
     ('theme', 'Set to "dark" to use a dark theme.', 'TEXT', TRUE, TRUE),
     ('footer', 'Muted text to display in the footer of the page. This can be used to display a link to the terms and conditions of your application, for instance. By default, shows "Built with SQLPage". Supports links with markdown.', 'TEXT', TRUE, TRUE)
 ) x;

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -144,12 +144,12 @@
     {{/if}}
 {{/inline}}
 
-<body class="layout-{{#if sidebar}}fluid{{else}}{{default layout 'boxed'}}{{/if}}" {{#if sidebar_theme}}data-bs-theme="{{sidebar_theme}}" {{/if}}>
+<body class="layout-{{#if sidebar}}fluid{{else}}{{default layout 'boxed'}}{{/if}}" {{#if theme}}data-bs-theme="{{theme}}" {{/if}}>
     <div class="page">
         {{#if (or (or title (or icon image)) menu_item)}}
         <header id="sqlpage_header">
         {{#if sidebar}}
-        <aside class="navbar navbar-vertical navbar-expand-lg" {{#if theme}}data-bs-theme="{{theme}}" {{/if}}>
+        <aside class="navbar navbar-vertical navbar-expand-lg" {{#if sidebar_theme}}data-bs-theme="{{sidebar_theme}}" {{/if}}>
             <div class="container-fluid">
                 <button class="navbar-toggler collapsed" type="button" data-bs-target="#sidebar-menu" aria-controls="sidebar-menu" data-bs-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>

--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -144,7 +144,7 @@
     {{/if}}
 {{/inline}}
 
-<body class="layout-{{#if sidebar}}fluid{{else}}{{default layout 'boxed'}}{{/if}}" {{#if theme}}data-bs-theme="{{theme}}" {{/if}}>
+<body class="layout-{{#if sidebar}}fluid{{else}}{{default layout 'boxed'}}{{/if}}" {{#if sidebar_theme}}data-bs-theme="{{sidebar_theme}}" {{/if}}>
     <div class="page">
         {{#if (or (or title (or icon image)) menu_item)}}
         <header id="sqlpage_header">


### PR DESCRIPTION
Change the "theme" property of sidebar as "sidebar_theme" (#540) and accept it as parameter and not a boolean.

I don't really know "where" to place the documentation, as the folder docs doesn't include the documentation.sql of the components nor the Markdown files with docs.