### PR TITLE
Fix textarea and select components ignoring class attribute

### DIFF
--- a/sqlpage/templates/form.handlebars
+++ b/sqlpage/templates/form.handlebars
@@ -46,7 +46,7 @@
                     {{#if (eq type 'textarea')}}
                         <textarea
                             name="{{name}}"
-                            class="form-control"
+                            class="form-control {{class}}"
                             placeholder="{{placeholder}}"
                             rows="{{default rows 3}}"
                             {{#if id}}id="{{id}}" {{/if~}}
@@ -61,7 +61,8 @@
                         {{~#if value includeZero=true}}{{value}}{{/if~}}
                         </textarea>
                     {{else}}{{#if (eq type 'select')}}
-                        <select name="{{name}}" class="form-select"
+                        <select name="{{name}}" 
+                            class="form-select {{class}}"
                         {{~#if id}} id="{{id}}" {{/if~}}
                         {{~#if required}} required="required" {{/if~}}
                         {{~#if autofocus}} autofocus {{/if~}}


### PR DESCRIPTION
I noticed that textarea form components and select form components would ignore my class attribute assignments. This PR fixes that template. 

How to use:

```
select 'form' as component;

-- should have a big margin below and a padding
select
  'select' as type,
  'Test Label' as label,
  'mb-4 p-3' as class,
  '[{"label":"Test Label","value":"test"}]' as options;

-- put a field here just to see that the margin worked
select 'test' as name;

-- should have a big margin above and a big margin below 
select 'textarea' as type, 'mb-4 mt-4' as class;

-- put another field here just to see that it worked
select 'test2' as name;
```