### PR TITLE
Submenu items not being marked as active when it is set to true. bug Something isn't working fixes #1063 

### DIFF
--- a/sqlpage/templates/shell.handlebars
+++ b/sqlpage/templates/shell.handlebars
@@ -95,7 +95,7 @@
                 {{~#with (parse_json this)}}
                     {{#if (or (or this.title this.icon) this.image)}}
                         <li class="nav-item{{#if this.submenu}} dropdown{{/if}}{{#if this.active}} active{{/if}}">
-                            <a class="nav-link {{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
+                            <a class="nav-link {{#if this.active}}active {{/if}}{{#if this.submenu}}dropdown-toggle{{/if}}" href="{{#if this.link}}{{this.link}}{{else}}#{{/if}}"
                                 {{~#if this.submenu}}
                                     data-bs-toggle="dropdown" 
                                     {{!-- commented out until this is fixed: https://github.com/tabler/tabler/issues/2485
@@ -125,7 +125,7 @@
                                 <div class="dropdown-menu dropdown-menu-end" data-bs-popper="static">
                                     {{~#each this.submenu~}}
                                         {{#if (or (or this.title this.icon) this.image)}}
-                                            <a class="dropdown-item" href="{{this.link}}" {{#if this.target}}target="{{this.target}}"{{/if}}>
+                                            <a class="dropdown-item{{#if this.active}} active{{/if}}" href="{{this.link}}" {{#if this.target}}target="{{this.target}}"{{/if}}>
                                                 {{~#if this.image~}}
                                                     <span {{~#if this.title}} class="me-1"{{/if}}>
                                                         {{~#if (eq ../this.size 'sm')}}


### PR DESCRIPTION
Add if active logic to the sub menu items of shell.handelbars.

Sidebar mode with active submen
<img width="273" height="461" alt="image" src="https://github.com/user-attachments/assets/a7926f3c-8787-4d25-8296-2638abbe1a6f" />
