### PR TITLE
fix ipv6 notation

### DIFF
--- a/src/webserver/http.rs
+++ b/src/webserver/http.rs
@@ -547,6 +547,8 @@ fn log_welcome_message(config: &AppConfig) {
                 "http://localhost:{port}\n\
             (also accessible from other devices using your IP address)"
             )
+        } else if ip.is_ipv6() {
+            format!("http://[{ip}]:{port}")
         } else {
             format!("http://{ip}:{port}")
         }


### PR DESCRIPTION
On Mac OS, when localhost:8080 is defined and sqlpage config file, the SocketAddr is resolved with ipv6 address if ip V6 is available on the internal network.

```json
{
  "listen_on": "localhost:8080"
}
```

On the terminal we can Ctrl + Click, but the URL is incorrect (ipV6 notation use bracket)

Actually we have 

```shell
View your website at:
🔗 http://::1:8080
```

Instead of 

```
View your website at:
🔗 http://[::1]:8080
```

Regards,