### PR TITLE
fix text-center for the edit_url action in table component

### DIFF
--- a/sqlpage/templates/table.handlebars
+++ b/sqlpage/templates/table.handlebars
@@ -89,7 +89,7 @@
                             {{/if~}}
                         {{~/each~}}
                             {{#if ../edit_url}}
-                            <td class="align-middle _col_edit">
+                            <td class="align-middle _col_edit text-center">
                                 <a href="{{replace ../edit_url '{id}' _sqlpage_id}}" class="align-middle link-secondary _col_edit" data-action="edit" title="Edit">
                                     {{~icon_img 'edit'~}}
                                 </a>


### PR DESCRIPTION
The edit_url action was not centered like the delete_url action in the table component.
This pull request fixes it.