### PR TITLE
feat(oidc): allow sub domain on localhost

### DIFF
--- a/src/webserver/oidc.rs
+++ b/src/webserver/oidc.rs
@@ -916,7 +916,9 @@ fn make_oidc_client(
         )
     })?;
     let needs_http = match redirect_url.url().host() {
-        Some(openidconnect::url::Host::Domain(domain)) => domain == "localhost",
+        Some(openidconnect::url::Host::Domain(domain)) => {
+            domain == "localhost" || domain.ends_with(".localhost")
+        }
         Some(openidconnect::url::Host::Ipv4(_) | openidconnect::url::Host::Ipv6(_)) => true,
         None => false,
     };


### PR DESCRIPTION
Hi :wave:

We develop on remote VMs with SSH port‑forward + reverse‑proxy per subdomain. 
This change makes the OIDC redirect URL use http:// when the configured is local (localhost, *.localhost, or an IP) so SSH port‑forward + reverse‑proxy dev workflows work, and keeps https:// for real domains.

Thanks for maintaining this project