### PR TITLE
Return 400 for invalid UTF-8 multipart fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG.md
 
 ## unreleased
- - Fixed a bug where the single-sign-on oidc code would generate an unbounded amount of cookies when receiving many unauthenticated requests in sequence. 
+
+- Fixed a bug where the single-sign-on oidc code would generate an unbounded amount of cookies when receiving many unauthenticated requests in sequence. 
+- Fix: invalid UTF-8 in multipart text fields now returns `400 Bad Request` instead of `500 Internal Server Error`.
 
 ## 0.43.0
 

--- a/src/webserver/http_request_info.rs
+++ b/src/webserver/http_request_info.rs
@@ -273,7 +273,14 @@ async fn extract_text(
         .await
         .map(|bytes| bytes.data)
         .map_err(|e| anyhow!("failed to read form field data: {e}"))?;
-    Ok(String::from_utf8(data.to_vec())?)
+    String::from_utf8(data.to_vec()).map_err(|e| {
+        anyhow!(super::ErrorWithStatus {
+            status: actix_web::http::StatusCode::BAD_REQUEST,
+        })
+        .context(format!(
+            "could not parse multipart form field as utf-8 text: {e}"
+        ))
+    })
 }
 
 async fn extract_file(

--- a/tests/requests/mod.rs
+++ b/tests/requests/mod.rs
@@ -188,4 +188,34 @@ async fn test_variables_function() -> actix_web::Result<()> {
     Ok(())
 }
 
+#[actix_web::test]
+async fn test_invalid_utf8_multipart_text_field_returns_bad_request() -> actix_web::Result<()> {
+    let req = get_request_to("/tests/requests/variables.sql")
+        .await?
+        .insert_header(("content-type", "multipart/form-data; boundary=1234567890"))
+        .set_payload(
+            b"--1234567890\r\n\
+            Content-Disposition: form-data; name=\"x\"\r\n\
+            Content-Type: text/plain\r\n\
+            \r\n\
+            \xff\r\n\
+            --1234567890--\r\n"
+                .as_slice(),
+        )
+        .to_srv_request();
+    let status = match main_handler(req).await {
+        Ok(resp) => resp.status(),
+        Err(err) => err.as_response_error().status_code(),
+    };
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "assertion error, expected 400 bad request on invalid utf8 payload, got {}",
+        status
+    );
+
+    Ok(())
+}
+
 mod webhook_hmac;


### PR DESCRIPTION
## Summary
- return 400 Bad Request when a multipart text field contains invalid UTF-8
- add a regression test covering the curl repro for malformed multipart payloads
- document the fix in CHANGELOG.md

## Verification
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test test_invalid_utf8_multipart_text_field_returns_bad_request -- --nocapture
- cargo test test_file_upload_direct -- --nocapture

## Repro
curl --http1.1 -X POST http://127.0.0.1:6281/tests/requests/variables.sql -H 'Content-Type: multipart/form-data; boundary=xxx' --data-binary @/tmp/sqlpage-invalid-multipart.bin
