### PR TITLE
Suppress startup logs for CLI-only invocations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,18 +7,36 @@ use sqlpage::{
 
 #[actix_web::main]
 async fn main() {
-    if let Err(e) = init_logging() {
-        eprintln!("Failed to initialize logging/telemetry: {e:#}");
-        std::process::exit(1);
+    let cli = match cli::arguments::parse_cli() {
+        Ok(cli) => cli,
+        Err(e) => {
+            eprintln!("{e:#}");
+            std::process::exit(1);
+        }
+    };
+
+    let is_server_mode = cli.command.is_none();
+
+    if is_server_mode {
+        if let Err(e) = init_logging() {
+            eprintln!("Failed to initialize logging/telemetry: {e:#}");
+            std::process::exit(1);
+        }
+    } else {
+        let _ = dotenvy::dotenv();
     }
-    if let Err(e) = start().await {
-        log::error!("{e:?}");
+
+    if let Err(e) = start(cli).await {
+        if is_server_mode {
+            log::error!("{e:?}");
+        } else {
+            eprintln!("{e:#}");
+        }
         std::process::exit(1);
     }
 }
 
-async fn start() -> anyhow::Result<()> {
-    let cli = cli::arguments::parse_cli()?;
+async fn start(cli: cli::arguments::Cli) -> anyhow::Result<()> {
     let app_config = AppConfig::from_cli(&cli)?;
 
     if let Some(command) = cli.command {


### PR DESCRIPTION
## Summary
- parse CLI args before telemetry initialization
- initialize logging only when running server mode (no subcommand)
- keep loading .env for CLI subcommands, but silently (no log output)

## Validation
- cargo run -- --help
- cargo run -- --version
- cargo run -- create-migration
- cargo run -- --config-dir "/tmp/sqlpage-cli-test-eIeR4r" create-migration x
- cargo run -- --web-root /definitely-not-there
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
